### PR TITLE
遗漏的GDK文本补充

### DIFF
--- a/texts/zh_CN.lang
+++ b/texts/zh_CN.lang
@@ -18108,4 +18108,3 @@ tile.frame=物品展示框	#
 resourcePack.incompatible.graphics.pbr=此包内含有启用灵动视效的信息，但你的设备不支持此选项。	#
 item.spawn_egg.entity.editor:map_marker.name=地图标记刷怪蛋	#
 entity.editor:map_marker.name=地图标记	#
-


### PR DESCRIPTION
在1.21.120正式版语言文件中发现GDK相关的文件遗漏了，需要补充更新一下